### PR TITLE
204 Cosmos DB with Managed Identity

### DIFF
--- a/modules/cosmos_db/identity.tf
+++ b/modules/cosmos_db/identity.tf
@@ -1,0 +1,19 @@
+# Existing Cosmos DB AzureRM provider only supported SystemAssigned Identity. Below block enables the options for both system and user assigned managed identities.
+# Type specification: "SystemAssigned", "UserAssigned" or "SystemAssigned,UserAssigned"
+resource "azapi_update_resource" "managed_identity_enable" {
+  count = var.identity.enabled ? 1 : 0
+  type      = "Microsoft.DocumentDB/databaseAccounts@2021-10-15"
+  resource_id = azurerm_cosmosdb_account.this.id
+  body = local.identity_body
+}
+
+resource "azapi_update_resource" "managed_identity_disable" {
+  count = var.identity.enabled ? 0 : 1
+  type      = "Microsoft.DocumentDB/databaseAccounts@2021-10-15"
+  resource_id = azurerm_cosmosdb_account.this.id
+  body = jsonencode({
+      identity = {
+        type = "None"
+      }
+  })
+}

--- a/modules/cosmos_db/identity_variables.tf
+++ b/modules/cosmos_db/identity_variables.tf
@@ -1,0 +1,13 @@
+variable "identity" {
+  type = object({
+    enabled = bool 
+    type = string
+    id = string 
+  })
+  default = {
+    enabled = false 
+    id = ""
+    type = ""
+  }
+  description = "Identity block to enable either system assigned identity, user assigned identity or both. Type should be set to either: \"SystemAssigned\", \"UserAssigned\" or \"SystemAssigned,UserAssigned\""
+}

--- a/modules/cosmos_db/locals.tf
+++ b/modules/cosmos_db/locals.tf
@@ -12,6 +12,20 @@ locals {
   firewall_ips         = var.firewall_ip == [] ? "${join(",", var.azure_portal_access, var.azure_dc_access)}" : "${join(",", var.firewall_ip, var.azure_portal_access, var.azure_dc_access)}"
   diag_settings_name   = "diag-${local.cosmos_account_name}"
   diag_logs            = var.cosmos_api == "sql" ? ["QueryRuntimeStatistics", "PartitionKeyRUConsumption"] : [var.logs_config[var.cosmos_api]]
+  identity_body = var.identity.type == "SystemAssigned" ? local.systemassigned_identity_body: local.userassigned_identity_body
+  userassigned_identity_body = jsonencode({
+    identity = {
+      type = var.identity.type
+      userAssignedIdentities = {
+        tostring(var.identity.id) = {}
+      }
+    }
+  })
+  systemassigned_identity_body = jsonencode({
+    identity = {
+      type = var.identity.type 
+    }
+  })
   tags = {
     Application_Name = var.application_name
     Environment      = var.environment

--- a/modules/cosmos_db/main.tf
+++ b/modules/cosmos_db/main.tf
@@ -1,3 +1,16 @@
+# Azure provider version 
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=2.84"
+    }
+    azapi = {
+      source = "azure/azapi"
+    }
+  }
+}
+
 resource "azurerm_cosmosdb_account" "this" {
   name                          = local.cosmos_account_name
   location                      = local.location
@@ -59,7 +72,10 @@ resource "azurerm_cosmosdb_account" "this" {
     }
   }
 
-  identity {
-    type = "SystemAssigned"
+  lifecycle {
+    # Ignoring identity block changes as this is managed outside of azurerm_cosmosdb_account resource
+    ignore_changes = [
+      identity
+    ]
   }
 }

--- a/samples/204-cosmosdb-managed-identity/main.tf
+++ b/samples/204-cosmosdb-managed-identity/main.tf
@@ -1,0 +1,50 @@
+# Azure provider version 
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=2.84"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+# Resource group 
+resource "azurerm_resource_group" "this" {
+  name     = var.resource_group_name
+  location = var.location
+}
+
+resource "azurerm_user_assigned_identity" "this" {
+  resource_group_name = azurerm_resource_group.this.name 
+  location = azurerm_resource_group.this.location 
+  name = "cosmosdb_uai"
+}
+
+/* 
+Notes for different managed identity settings
+ - Set identity.type = "SystemAssigned" and id ="" for system-assigned only
+ - Set identity.type = "UserAssigned" and id = azurerm_user_assigned_identity.this.id for user-assigned only 
+ - Set identity.type = "SystemAssigned,UserAssigned" and id = azurerm_user_assigned_identity.this.id  for both user and system assigned identity
+*/ 
+module "azure_cosmos_db" {
+  source              = "../../modules/cosmos_db"
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+  cosmos_account_name = var.cosmos_account_name
+  cosmos_api          = var.cosmos_api
+  sql_dbs             = var.sql_dbs
+  sql_db_containers   = var.sql_db_containers
+  identity = {
+    enabled = true 
+    type = "UserAssigned" 
+    id = azurerm_user_assigned_identity.this.id
+  }
+  depends_on = [
+    azurerm_resource_group.this,
+    azurerm_user_assigned_identity.this 
+  ]
+}

--- a/samples/204-cosmosdb-managed-identity/readme.md
+++ b/samples/204-cosmosdb-managed-identity/readme.md
@@ -1,0 +1,34 @@
+# 204 Cosmos DB SQL API with Managed Identity
+This template deploys a cosmos db account with 2 sql databases (autoscale and no autoscale) and 2 cointainers (per each db) with user assigned managed identity enabled. This sample assumes that a resource group and user managed identity has been previously created and is referenced as an input parameter. A sample input parameters file has been included as part of this example.
+
+For the identity input parameters: 
+- Set identity.type = "SystemAssigned" and id ="" for system-assigned only
+- Set identity.type = "UserAssigned" and id = azurerm_user_assigned_identity.this.id for user-assigned only 
+- Set identity.type = "SystemAssigned,UserAssigned" and id = azurerm_user_assigned_identity.this.id  for both user and system assigned identity
+If user assigned identity is enabled, it can't be disabled with the rest-api provider at the moment. 
+
+## Variables 
+| Name | Description |
+|-|-|
+| resource_group_name | Name of existing resource group |
+| location | Location where cosmos db will be deployed to | 
+| cosmos_account_name | Name of cosmos db account | 
+| cosmos_api | API for Cosmos db, should be "sql" in this example | 
+| sql_dbs | Cosmos SQL DBs to create | 
+| sql_db_containers | Cosmos SQL DB containers to create per each db | 
+| identity | Identity parameters for managed identity usage: Supports both user and system assigned identities" | 
+
+Please see terraform.tfvars.sample for example inputs. Above is the minimal input requirements for the cosmos db module. 
+
+## Usage
+```bash
+terraform plan -out example.tfplan
+terraform apply example.tfplan
+```
+
+# Contribute
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the Microsoft Open Source Code of Conduct. For more information see the Code of Conduct FAQ or contact opencode@microsoft.com with any additional questions or comments.

--- a/samples/204-cosmosdb-managed-identity/terraform.tfvars.sample
+++ b/samples/204-cosmosdb-managed-identity/terraform.tfvars.sample
@@ -1,0 +1,67 @@
+resource_group_name = "rg-sample-204"
+location            = "eastus"
+cosmos_account_name = "samplecosmosacct204"
+cosmos_api          = "sql"
+sql_dbs = {
+  one = {
+    db_name           = "dbnoautoscale"
+    db_throughput     = 400
+    db_max_throughput = null
+  },
+  two = {
+    db_name           = "dbautoscale"
+    db_throughput     = null
+    db_max_throughput = 1000
+  }
+}
+sql_db_containers = {
+  one = {
+    container_name           = "container1"
+    db_name                  = "dbnoautoscale"
+    partition_key_path       = "/container/id"
+    partition_key_version    = 2
+    container_throughout     = 400
+    container_max_throughput = null
+    indexing_policy_settings = {
+      sql_indexing_mode = "consistent"
+      sql_included_path = "/*"
+      sql_excluded_path = null
+      composite_indexes = {
+        compositeindexone = {
+          indexes = [
+            {
+              path  = "/container/name"
+              order = "Ascending"
+            },
+            {
+              path  = "/container/id"
+              order = "Ascending"
+            }
+          ]
+        }
+      }
+      spatial_indexes = {
+        spatialindexone = {
+          path = "/*"
+        }
+      }
+    }
+    sql_unique_key = ["/container/id"]
+  },
+  two = {
+    container_name           = "container1"
+    db_name                  = "dbautoscale"
+    partition_key_path       = "/container/id"
+    partition_key_version    = 2
+    container_throughout     = 500
+    container_max_throughput = null
+    indexing_policy_settings = {
+      sql_indexing_mode = "consistent"
+      sql_included_path = "/*"
+      sql_excluded_path = "/excluded/?"
+      composite_indexes = {}
+      spatial_indexes   = {}
+    }
+    sql_unique_key = ["/container/id"]
+  }
+}

--- a/samples/204-cosmosdb-managed-identity/variables.tf
+++ b/samples/204-cosmosdb-managed-identity/variables.tf
@@ -1,0 +1,14 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Resource Group Name"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure Region"
+}
+
+variable "cosmos_account_name" {}
+variable "cosmos_api" {}
+variable "sql_dbs" {}
+variable "sql_db_containers" {}


### PR DESCRIPTION
- Updated cosmos db to use azapi provider for user managed identity (currently not supported within azurerm cosmos account) 
- Created example for 204 cosmos db account with managed identity 
- Noted bug: Cant erase/disable user assigned managed identity with subsequent disable API call.